### PR TITLE
To the foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ start({ connect: true, force: true }, function(err, sim) {
 ```
 -->
 
+## Documentation
+
+If you want to contribute to this module, it might be interesting to have a look at the way WebIDE launches the simulator. The code for this is in [simulator-process.js](https://dxr.mozilla.org/mozilla-central/source/b2g/simulator/lib/simulator-process.js). Whenever possible, we want to mimic the WebIDE experience as closely as possible.
+
 ## History
 
 This is based on initial work on fxos-start by Nicola Greco.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = startSimulator;
 
 function startSimulator(options) {
 
+  options = options || {};
   var detached = options.detached ? true : false;
   var verbose = options.verbose ? true : false;
   var port = options.port;

--- a/index.js
+++ b/index.js
@@ -189,7 +189,8 @@ function startSimulatorProcess(options) {
       [
         '-profile', options.profile,
         '-start-debugger-server', options.port,
-        '-no-remote'
+        '-no-remote',
+		'-foreground'
       ],
       childOptions
     );

--- a/index.js
+++ b/index.js
@@ -85,7 +85,6 @@ function findAvailablePort(preferredPort) {
       if (err) {
         reject(err);
       } else {
-        console.log('got this port', port);
         resolve(port);
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-firefox-start-simulator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Start a Firefox OS simulator",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This makes sure the simulator is not behind the rest of the windows when started
