### PR TITLE
startSimulator.all() utility to work better with findSimulators()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,32 @@ where `options` is a plain `Object` with any of the following:
 and `simulator` is an object containing:
 
 * `binary`: path to the simulator binary
+* 'bin': an alias to `binary`
 * `profile`: path to the simulator profile
 * `pid`: process id
 * `process`: the actual process object
 * `port`: the port where the simulator is listening for debugging connections
+
+There is also a `startSimulator.all()` utility to launch many simulators at once:
+
+```javascript
+startSimulator.all(options)(simulatorOptions)
+  .then(function(launchedSimulators) {
+    // launchedSimulators is a list of simulator objects
+  });
+```
+
+The `options` parameter here is the same as above - these options will be
+commonly applied to all the simulators launched. 
+
+The call to `startSimulator.all()` returns a function that takes a list of
+simulators and returns a Promise to launch them all.  The result of that
+Promise is `launchedSimulators`, a list of all the simulators that were
+launched.
+
+Note: This function returning a function may seem like a roundabout way to do
+things, but take a look at the examples below to see how this works with
+`findSimulators()` and other Promise-based APIs.
 
 ## Examples
 
@@ -69,6 +91,17 @@ startSimulator().then(function(simulator) {
   console.log('Error starting a simulator', err);
 });
 
+```
+
+### Start all simulators found on your system
+```javascript
+var findSimulators = require('node-firefox-find-simulators');
+var startSimulator = require('node-firefox-start-simulator');
+
+// startSimulator.all() returns a function that applies the common options to
+// all the simulators discovered by findSimulators()
+
+findSimulators.then(startSimulator.all({ detached: true }));
 ```
 
 Have a look at the `examples` folder for more!

--- a/index.js
+++ b/index.js
@@ -53,35 +53,37 @@ function startSimulator(options) {
 }
 
 // Helper function to start multiple simulators with common default options
-startSimulator.all = function (commonOptions) {
-  return function (simulators) {
+startSimulator.all = function(commonOptions) {
+
+  return function(simulators) {
 
     // findSimulators() output can include multiple emulators for the same
     // version. Filter that down to unique versions.
     var seenVersions = {};
-    var uniqueVersionSimulators = simulators.filter(function (simulator) {
+    var uniqueVersionSimulators = simulators.filter(function(simulator) {
       var key = simulator.version;
       if (key in seenVersions) {
         return false;
-      } else {
-        seenVersions[key] = true;
-        return true;
       }
+      seenVersions[key] = true;
+      return true;
     });
 
     // Start all the simulators, using the common options for each.
-    return Promise.all(uniqueVersionSimulators.map(function (simulator) {
+    return Promise.all(uniqueVersionSimulators.map(function(simulator) {
       var options = {};
-      for (var key in commonOptions) {
+      var key;
+      for (key in commonOptions) {
         options[key] = commonOptions[key];
       }
-      for (var key in simulator) {
+      for (key in simulator) {
         options[key] = simulator[key];
       }
       return startSimulator(options);
     }));
 
   };
+
 };
 
 // Find a simulator that matches the options

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "devDependencies": {
     "gulp": "^3.8.10",
     "mocha": "^1.21.4",
-    "should": "^4.0.4",
-    "node-firefox-build-tools": "^0.1.0"
+    "mockery": "^1.4.0",
+    "node-firefox-build-tools": "^0.1.0",
+    "nodemock": "^0.3.4",
+    "should": "^4.0.4"
   },
   "scripts": {
     "gulp": "gulp",

--- a/tests/unit/test.index.js
+++ b/tests/unit/test.index.js
@@ -143,8 +143,6 @@ module.exports = {
       test.done();
     }).then(function(results) {
 
-      // console.log(JSON.stringify(results, null, ' '));
-
       // Ensure all the mocks were called, and with the expected parameters
       test.ok(mocked.assert());
 
@@ -181,12 +179,6 @@ module.exports = {
     });
 
   },
-
-  /*
-  'startSimulator.all() launches only one simulator per unique version': function(test) {
-    test.done();
-  },
-  */
 
   setUp: function(done) {
     return done();

--- a/tests/unit/test.index.js
+++ b/tests/unit/test.index.js
@@ -3,6 +3,14 @@
 var path = require('path');
 var net = require('net');
 
+/* global -Promise */
+var Promise = require('es6-promise').Promise;
+var mockery = require('mockery');
+var nodemock = require('nodemock');
+
+// nodemock expects an empty function to indicate a callback parameter
+var CALLBACK_TYPE = function() {};
+
 // Switch env vars to point at the mocked up home / profile test data so that
 // findSimulators finds one of our mock simulators.
 var home = path.join(__dirname, 'data', process.platform);
@@ -18,8 +26,177 @@ if ('win32' === process.platform) {
 var startSimulator = require('../../index');
 
 module.exports = {
+
   'startSimulator spawns with an available port': testStartSimulator(),
-  'startSimulator spawns with specified port 2112': testStartSimulator(2112)
+
+  'startSimulator spawns with specified port 2112': testStartSimulator(2112),
+
+  'startSimulator.all() launches multiple simulators': function(test) {
+
+    var simulators = [
+      { version: '1.4', bin: '/bin/b2g-1.4', profile: '/profile/b2g-1.4' },
+      { version: '2.0', bin: '/bin/b2g-2.0', profile: '/profile/b2g-2.0' },
+      { version: '2.2', bin: '/bin/b2g-2.2', profile: '/profile/b2g-2.2' }
+    ];
+
+    var ports = [ 8008, 8010, 8012 ];
+
+    var mocked = nodemock.ignore('test');
+
+    // Mock up findSimulators fed by test data.
+    mockery.registerMock('node-firefox-find-simulators', function(opts) {
+      return new Promise(function(resolve, reject) {
+        if (opts.version) {
+          return resolve(simulators.filter(function(simulator) {
+            return simulator.version === opts.version;
+          }));
+        }
+        return resolve(simulators);
+      });
+    });
+
+    // Mock fs.existsSync that finds simulator binaries in test data.
+    mockery.registerMock('fs', {
+      existsSync: function(filename) {
+        var found = simulators.filter(function(simulator) {
+          return simulator.bin === filename;
+        });
+        return found.length > 0;
+      }
+    });
+
+    // Mock portfinder.getPort that pulls from a series of test ports.
+    var portsIdx = 0;
+    mockery.registerMock('portfinder', {
+      getPort: function(callback) {
+        callback(null, ports[portsIdx++]);
+      }
+    });
+
+    // Mock up child_process.spawn to assert expected launched simulators
+    for (var spawnIndex = 0; spawnIndex < simulators.length; spawnIndex++) {
+      var bin = simulators[spawnIndex].bin;
+      var args = [
+        '-profile', simulators[spawnIndex].profile,
+        '-start-debugger-server', ports[spawnIndex],
+        '-no-remote', '-foreground'
+      ];
+      var options = {
+        'stdio': ['ignore','ignore','ignore'],
+        'detached': true
+      };
+      mocked.mock('spawn')
+        .takes(bin, args, options)
+        .returns({
+          pid: spawnIndex,
+          bin: bin,
+          args: args,
+          options: options,
+          unref: CALLBACK_TYPE
+        });
+    }
+
+    mockery.registerMock('child_process', {
+      spawn: mocked.spawn
+    });
+
+    for (var connectIndex = 0; connectIndex < ports.length; connectIndex++) {
+      mocked.mock('connect')
+        .takes(ports[connectIndex], 'localhost')
+        .returns(true);
+    }
+
+    function MockSocket() { /* no-op */ }
+
+    MockSocket.prototype = {
+      connect: function(port, host) {
+        return mocked.connect(port, host);
+      },
+      on: function(event, callback) {
+        if (event === 'connect') {
+          setImmediate(callback);
+        }
+        return this;
+      },
+      destroy: function() {
+        return true;
+      }
+    };
+
+    mockery.registerMock('net', {
+      Socket: MockSocket
+    });
+
+    // Enable mocks on a clear import cache
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+
+    // Require a freshly imported forwardPorts for this test
+    var startSimulatorWithMocks = require('../../index');
+    var startSimulatorPromise = startSimulatorWithMocks.all({ detached: true })(simulators);
+
+    startSimulatorPromise.catch(function(err) {
+      test.ifError(err);
+      test.done();
+    }).then(function(results) {
+
+      // console.log(JSON.stringify(results, null, ' '));
+
+      // Ensure all the mocks were called, and with the expected parameters
+      test.ok(mocked.assert());
+
+      // Putting all the mocks together, this is what the results on the other
+      // end should look like after "starting" simulators
+      var expected = [];
+      for (var simulatorIndex = 0; simulatorIndex < simulators.length; simulatorIndex++) {
+        var simulator = simulators[simulatorIndex];
+        expected.push({
+          process: {
+            pid: simulatorIndex,
+            bin: simulator.bin,
+            args: [
+              '-profile', simulator.profile,
+              '-start-debugger-server', ports[simulatorIndex],
+              '-no-remote', '-foreground'
+            ],
+            options: {
+              'stdio': [ 'ignore', 'ignore', 'ignore' ],
+              'detached': true
+            },
+            unref: CALLBACK_TYPE
+          },
+          pid: simulatorIndex,
+          port: ports[simulatorIndex],
+          binary: simulator.bin,
+          profile: simulator.profile
+        });
+      }
+
+      test.deepEqual(results, expected);
+
+      test.done();
+    });
+
+  },
+
+  /*
+  'startSimulator.all() launches only one simulator per unique version': function(test) {
+    test.done();
+  },
+  */
+
+  setUp: function(done) {
+    return done();
+  },
+
+  tearDown: function(done) {
+    mockery.disable();
+    return done();
+  }
+
 };
 
 function testStartSimulator(testPort) {


### PR DESCRIPTION
This enables simplified cooperation between `findSimulators()` and `startSimulator()` like so:

``` javascript
findSimulators().then(startSimulator.all({ detached: true }))
```

For bonus points, I worked out how to test `startSimulator()` using mocks instead of launching external processes. I'll probably follow this PR up with refactorings to extend that approach to the other existing tests.
