### PR TITLE
Fix issue where ports between devices and simulators get clobbered

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,11 @@ function findAvailablePort(preferredPort) {
       portFinder.basePort = preferredPort;
     }
 
-    portFinder.getPort(function(err, port) {
+    portFinder.getPort({
+      // Ensure we're looking at localhost, rather than 0.0.0.0
+      // see: https://github.com/indexzero/node-portfinder/issues/13
+      host: '127.0.0.1'
+    }, function(err, port) {
       if (err) {
         reject(err);
       } else {

--- a/tests/unit/test.index.js
+++ b/tests/unit/test.index.js
@@ -68,7 +68,8 @@ module.exports = {
     // Mock portfinder.getPort that pulls from a series of test ports.
     var portsIdx = 0;
     mockery.registerMock('portfinder', {
-      getPort: function(callback) {
+      getPort: function(options, callback) {
+        test.equal(options.host, '127.0.0.1');
         callback(null, ports[portsIdx++]);
       }
     });


### PR DESCRIPTION
So, by default, [portfinder looks for ports on host `0.0.0.0`](https://github.com/indexzero/node-portfinder/issues/13). That's the "any" interface, which is separate from localhost at `127.0.0.1`. 

This causes issues: `adb` port forwards and simulator debug ports show up on `127.0.0.1`. So, portfinder ends up finding free ports on `0.0.0.0` that are actually occupied on `127.0.0.1` and things break.
